### PR TITLE
fix trivy scan not finding ecr image

### DIFF
--- a/.github/workflows/ci-custom-build.yaml
+++ b/.github/workflows/ci-custom-build.yaml
@@ -113,6 +113,16 @@ jobs:
       DOJO_URL: ${{ inputs.DOJO_URL }}
       image-name: ${{ inputs.image-name }}
     steps:
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Set GITHUB_RUN_NUMBER
+        id: set_github_run_number
+        run: |
+          echo GITHUB_RUN_NUMBER=$(( GITHUB_RUN_NUMBER + 279 ))>> $GITHUB_ENV
+          echo "outtag=$((GITHUB_RUN_NUMBER + 279))" >> $GITHUB_OUTPUT
+  
       - name: Trivy vulnerability Scan and Import DefectDojo
         if: inputs.enable_trivy == true
         run: |


### PR DESCRIPTION
fixing the following error 
![image](https://github.com/Ubix/github-actions-workflows/assets/43704198/8457963d-303b-432a-9b9b-e4c5795cbffc)
